### PR TITLE
sharing GA code

### DIFF
--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,0 +1,9 @@
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-113003507-1"></script>
+<script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'UA-113003507-1');
+</script>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -56,13 +56,4 @@ layout: default
 
 <script id="dsq-count-scr" src="//https-0909v-github-io.disqus.com/count.js" async></script>
 
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-113003507-1"></script>
-<script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'UA-113003507-1');
-</script>
-
+{% include analytics.html %}

--- a/index.html
+++ b/index.html
@@ -20,3 +20,5 @@ layout: default
 </div>
 
 <a href="Wer%20bin%20ich%3F%201.html">Wer bin ich</a>
+
+{% include analytics.html %}


### PR DESCRIPTION
Startseite und Post-Seite sollen sich den Code für Google-Analytics teilen.